### PR TITLE
[Refactor/notice-1] 🔨 Refactor: 에러 처리용 스타일 컴포넌트 추가 및 타입 정의 분리 / 컴포넌트 의존성 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "roome-admin-fe",
+  "name": "notice",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.22.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -69,6 +69,7 @@ export const fetchNoticeWithDetails = async () => {
         try {
           return await fetchPost(notice.postUuid);
         } catch (error) {
+          console.error(error);
           throw new Error(
             `공지사항 ${notice.id}번의 상세 정보를 불러오는데 실패했습니다.`,
           );
@@ -82,6 +83,7 @@ export const fetchNoticeWithDetails = async () => {
         try {
           return await fetchLocalization(post.titleLocalizationUuid);
         } catch (error) {
+          console.error(error);
           throw new Error(
             `공지사항 제목의 번역 정보를 불러오는데 실패했습니다.`,
           );

--- a/src/pages/Notice/components/Datetime.tsx
+++ b/src/pages/Notice/components/Datetime.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@mui/material';
 import { formatDate } from '@/utils/dateformat';
+
 interface DatetimeProps {
   datetime: string;
 }

--- a/src/pages/Notice/components/Notice.style.tsx
+++ b/src/pages/Notice/components/Notice.style.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
+
 export const StyledListItem = styled.li`
   border-top: 1px solid var(--darkGray);
   list-style: none;
@@ -20,6 +21,17 @@ export const StyledSkeleton = styled.li`
   border-top: 1px solid var(--darkGray);
   list-style: none;
   padding: 2.25rem 1.25rem;
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const ErrorState = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 2.25rem 1.25rem;
+  text-decoration: none;
   display: flex;
   justify-content: left;
   align-items: center;

--- a/src/pages/Notice/components/NoticeItem.tsx
+++ b/src/pages/Notice/components/NoticeItem.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import { fetchPost } from '@/api/notice';
 import { INotice, IPost } from '@carebell/bell-core';
 import Post from './Post';
 import Datetime from './Datetime';
-import { StyledListItem, StyledLink } from './Notice.style';
+import { StyledListItem, StyledLink, ErrorState } from './Notice.style';
 import NoticeSkeletonItem from './NoticeSkeletonItem';
 import { ErrorContext } from '@/contexts/ErrorContext';
 
@@ -16,7 +16,7 @@ const NoticeItem = ({ notice }: NoticeResponse) => {
   const [loading, setLoading] = useState(true);
   const errorContext = useContext(ErrorContext);
 
-  const fetchPostData = async () => {
+  const fetchPostData = useCallback(async () => {
     try {
       const postData = await fetchPost(notice.postUuid);
       setPost(postData);
@@ -26,18 +26,18 @@ const NoticeItem = ({ notice }: NoticeResponse) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [notice.postUuid, errorContext]);
 
   useEffect(() => {
     fetchPostData();
-  }, [notice.postUuid]);
+  }, [fetchPostData]);
 
   if (loading) {
     return <NoticeSkeletonItem />;
   }
 
   if (!post) {
-    return null;
+    return <ErrorState>데이터를 불러올 수 없습니다.</ErrorState>;
   }
 
   return (

--- a/src/pages/Notice/components/NoticeList.tsx
+++ b/src/pages/Notice/components/NoticeList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import { fetchNoticeList } from '@/api/notice';
 import { INotice } from '@carebell/bell-core';
 import NoticeItem from './NoticeItem';
@@ -18,7 +18,7 @@ const NoticeList = () => {
   const [loading, setLoading] = useState(true);
   const errorContext = useContext(ErrorContext);
 
-  const fetchNotices = async () => {
+  const fetchNotices = useCallback(async () => {
     try {
       const response = await fetchNoticeList();
       setNoticeResponse(response);
@@ -28,11 +28,11 @@ const NoticeList = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [errorContext]);
 
   useEffect(() => {
     fetchNotices();
-  }, []);
+  }, [fetchNotices]);
 
   if (loading) {
     return Array.from({ length: 5 }).map((_, index) => (

--- a/src/pages/Notice/components/NoticeList.tsx
+++ b/src/pages/Notice/components/NoticeList.tsx
@@ -4,6 +4,7 @@ import { INotice } from '@carebell/bell-core';
 import NoticeItem from './NoticeItem';
 import NoticeSkeletonItem from './NoticeSkeletonItem';
 import { ErrorContext } from '@/contexts/ErrorContext';
+import { NoticeItemProps } from '@/types/Notice/NoticeItem.type';
 
 interface ListResponse {
   count: number;
@@ -44,16 +45,7 @@ const NoticeList = () => {
       {noticeResponse?.rows.map((notice) => (
         <NoticeItem
           key={notice.id}
-          notice={{
-            id: notice.id,
-            postUuid: notice.postUuid,
-            updatedAt: notice.updatedAt,
-            createdAt: notice.createdAt,
-            userUuid: notice.userUuid,
-            uuid: notice.uuid,
-            visibility: notice.visibility,
-            deletedAt: notice.deletedAt,
-          }}
+          notice={NoticeItemProps(notice)}
         />
       ))}
     </ul>

--- a/src/pages/Notice/components/NoticePageSkeleton.tsx
+++ b/src/pages/Notice/components/NoticePageSkeleton.tsx
@@ -6,15 +6,10 @@ const NoticePageSkeleton = () => {
     <Box>
       <Box sx={{ mb: 4 }}>
         <Skeleton
-          variant='rectangular'
+          variant='rounded'
           width={120}
-          height={32}
+          height={56}
           sx={{ mb: 1 }}
-        />
-        <Skeleton
-          variant='text'
-          width='60%'
-          height={24}
         />
       </Box>
 

--- a/src/pages/Notice/components/NoticeSkeletonItem.tsx
+++ b/src/pages/Notice/components/NoticeSkeletonItem.tsx
@@ -7,13 +7,13 @@ const NoticeSkeletonItem = () => {
       <Skeleton
         variant='rounded'
         width={100}
-        height={20}
+        height={30}
         animation='wave'
       />
       <Skeleton
         variant='rounded'
         width={300}
-        height={20}
+        height={30}
         animation='wave'
       />
     </StyledSkeleton>

--- a/src/pages/Notice/components/Post.tsx
+++ b/src/pages/Notice/components/Post.tsx
@@ -27,7 +27,7 @@ const Post = ({ post }: PostProps) => {
       <Skeleton
         variant='rounded'
         width={300}
-        height={20}
+        height={30}
         animation='wave'
       />
     );

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,14 +1,14 @@
 import { Routes, Route } from 'react-router-dom';
 import NoticePage from '@/pages/Notice/NoticePage';
 import NoticeSkeletonItem from '@/pages/Notice/components/NoticeSkeletonItem';
-import MainPage from '@/pages/Main/MainPage';
+import NoticePageSkeleton from '@/pages/Notice/components/NoticePageSkeleton';
 
 const Router = () => {
   return (
     <Routes>
       <Route
         path='/'
-        element={<MainPage />}
+        element={<NoticePageSkeleton />}
       />
       <Route
         path='/notice'

--- a/src/types/Notice/NoticeItem.type.ts
+++ b/src/types/Notice/NoticeItem.type.ts
@@ -1,0 +1,12 @@
+import { INotice } from '@carebell/bell-core';
+
+export const NoticeItemProps = (notice: INotice): INotice => ({
+  id: notice.id,
+  postUuid: notice.postUuid,
+  updatedAt: notice.updatedAt,
+  createdAt: notice.createdAt,
+  userUuid: notice.userUuid,
+  uuid: notice.uuid,
+  visibility: notice.visibility,
+  deletedAt: notice.deletedAt,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,6 +784,11 @@
   resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -811,10 +816,34 @@
   resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/react-dom/-/react-dom-19.1.5.tgz#cdfe2c663742887372f54804b16e8dbc26bd794a"
   integrity sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==
 
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.20"
+  resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.12":
   version "4.4.12"
   resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
+
+"@types/react@*":
+  version "19.1.5"
+  resolved "https://nexus.zeroweb.kr/repository/npm-proxy/@types/react/-/react-19.1.5.tgz#9feb3bdeb506d0c79d8533b6ebdcacdbcb4756db"
+  integrity sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==
+  dependencies:
+    csstype "^3.0.2"
 
 "@types/react@^19.0.10":
   version "19.1.4"


### PR DESCRIPTION
### ⚒️ 수정 내용
---

1. 타입 정의 분리
   - `NoticeItemProps` 타입을 별도 파일로 분리
-> 문제: 기존에 NoticeList에서 NoticeItem로 props 전달시 모든 항목을 나열해서 가독성 및 유지보수성을 해침

2. 에러 처리 개선
   - `NoticeItem` 컴포넌트에서 post 데이터 없음 상태 처리 추가 (`ErrorState` 컴포넌트 추가)
-> 문제: post 데이터가 없을 때 단순 null 처리
-> 수정: 기존 스타일을 유지하면서 '데이터를 불러올 수 없습니다.' 라는 명확한 내용 전달

3. React Hook 의존성 처리
   - `useCallback`을 사용하여 `fetchNotices` 함수 메모이제이션
   - `useEffect` 의존성 경고 해결 (useEffect 내부에서 사용되는 fetchNotices 함수가 의존성 배열에 포함되지 않아 발생한 경고)

<br>

### 🗂️ 관련 이슈 필터링
---
#1 