### PR TITLE
[Feat/localization-16] :sparkles:Feat: 언어 설정 기능 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
-  <body>
+  <body class="lang-ko">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
 import { BrowserRouter } from 'react-router-dom';
 
 import { ErrorProvider } from '@/contexts/ErrorContext';
+import { LanguageProvider } from '@/contexts/LanguageContext';
 import Router from '@/routes/Router';
 
 function App() {
   return (
     <ErrorProvider>
-      <BrowserRouter>
-        <Router />
-      </BrowserRouter>
+      <LanguageProvider>
+        <BrowserRouter>
+          <Router />
+        </BrowserRouter>
+      </LanguageProvider>
     </ErrorProvider>
   );
 }

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,139 @@
+import React, { createContext, Component } from 'react';
+
+import { ILocalization } from '@carebell/bell-core';
+
+import {
+  Language,
+  LanguageContextType,
+  LanguageProviderProps,
+  LanguageProviderState,
+} from '@/types/LanguageContext/LanguageContext.type';
+
+const LanguageContext = createContext<LanguageContextType | undefined>(
+  undefined,
+);
+
+const LANGUAGE_STORAGE_KEY = 'preferred-language';
+
+export class LanguageProvider extends Component<
+  LanguageProviderProps,
+  LanguageProviderState
+> {
+  constructor(props: LanguageProviderProps) {
+    super(props);
+
+    const savedLanguage = this.getSavedLanguage();
+
+    this.state = {
+      currentLanguage: savedLanguage,
+    };
+  }
+
+  componentDidMount() {
+    this.updateDOM(this.state.currentLanguage);
+  }
+
+  getSavedLanguage = (): Language => {
+    try {
+      const saved = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+      if (saved && ['default', 'ko', 'en', 'ja'].includes(saved)) {
+        return saved as Language;
+      }
+    } catch (error) {
+      console.warn('로컬스토리지에서 언어 설정을 불러올 수 없습니다:', error);
+    }
+    return 'default';
+  };
+
+  saveLanguage = (language: Language) => {
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    } catch (error) {
+      console.warn('로컬스토리지에 언어 설정을 저장할 수 없습니다:', error);
+    }
+  };
+
+  updateDOM = (language: Language) => {
+    // HTML lang 속성 변경
+    if (language !== 'default') {
+      document.documentElement.lang = language;
+    } else {
+      document.documentElement.lang = 'ko';
+    }
+
+    // body 클래스 변경
+    const bodyElement = document.body;
+    bodyElement.className = bodyElement.className.replace(/lang-\w+/g, '');
+
+    if (language !== 'default') {
+      bodyElement.classList.add(`lang-${language}`);
+    } else {
+      bodyElement.classList.add('lang-ko');
+    }
+  };
+
+  setLanguage = (language: Language) => {
+    this.setState({ currentLanguage: language });
+    this.updateDOM(language);
+    this.saveLanguage(language);
+  };
+
+  getLocalizedContent = (localization: ILocalization | null): string => {
+    if (!localization) return '';
+
+    // 선택된 언어에 따라 해당 속성 반환
+    if (this.state.currentLanguage === 'default') {
+      return localization.default || '';
+    }
+
+    return (
+      localization[this.state.currentLanguage] || localization.default || ''
+    );
+  };
+
+  render() {
+    const contextValue: LanguageContextType = {
+      currentLanguage: this.state.currentLanguage,
+      setLanguage: this.setLanguage,
+      getLocalizedContent: this.getLocalizedContent,
+    };
+
+    return (
+      <LanguageContext.Provider value={contextValue}>
+        {this.props.children}
+      </LanguageContext.Provider>
+    );
+  }
+}
+
+export function withLanguage<P extends object>(
+  WrappedComponent: React.ComponentType<P & LanguageContextType>,
+) {
+  return class WithLanguageComponent extends Component<P> {
+    static contextType = LanguageContext;
+    declare context: React.ContextType<typeof LanguageContext>;
+
+    render() {
+      if (!this.context) {
+        throw new Error('withLanguage must be used within a LanguageProvider');
+      }
+
+      return (
+        <WrappedComponent
+          {...(this.props as P)}
+          {...this.context}
+        />
+      );
+    }
+  };
+}
+
+export const useLanguage = (): LanguageContextType => {
+  const context = React.useContext(LanguageContext);
+  if (context === undefined) {
+    throw new Error('언어 컨텍스트가 없습니다.');
+  }
+  return context;
+};
+
+export { LanguageContext };

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -2,14 +2,46 @@ import React from 'react';
 
 import { Link } from 'react-router-dom';
 
-class MainPage extends React.Component {
+import { FormControl, InputLabel } from '@mui/material';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+
+import { withLanguage } from '@/contexts/LanguageContext';
+import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+
+class MainPage extends React.Component<LanguageContextType> {
+  handleChange = (event: SelectChangeEvent) => {
+    const selectedLanguage = event.target.value as
+      | 'default'
+      | 'ko'
+      | 'en'
+      | 'ja';
+    this.props.setLanguage(selectedLanguage);
+    console.log('언어 변경', selectedLanguage);
+  };
+
   render() {
+    const { currentLanguage } = this.props;
+
     return (
       <div>
         <Link to='/notice'>공지사항 페이지로 이동</Link>
+        <FormControl
+          sx={{ m: 1, minWidth: 120 }}
+          size='small'>
+          <InputLabel id='demo-select-small-label'>Language</InputLabel>
+          <Select
+            value={currentLanguage}
+            onChange={this.handleChange}>
+            <MenuItem value='default'>기본 언어</MenuItem>
+            <MenuItem value='ko'>한국어</MenuItem>
+            <MenuItem value='en'>English</MenuItem>
+            <MenuItem value='ja'>日本語</MenuItem>
+          </Select>
+        </FormControl>
       </div>
     );
   }
 }
 
-export default MainPage;
+export default withLanguage(MainPage);

--- a/src/pages/Notice/components/Post.tsx
+++ b/src/pages/Notice/components/Post.tsx
@@ -4,15 +4,17 @@ import { Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
 import { ErrorContext } from '@/contexts/ErrorContext';
+import { withLanguage } from '@/contexts/LanguageContext';
+import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
 import { PostProps, PostState } from '@/types/Notice/Post.type';
 
 import PostSkeleton from './PostSkeleton';
 
-class Post extends React.Component<PostProps, PostState> {
+class Post extends React.Component<PostProps & LanguageContextType, PostState> {
   static contextType = ErrorContext;
   declare context: React.ContextType<typeof ErrorContext>;
 
-  constructor(props: PostProps) {
+  constructor(props: PostProps & LanguageContextType) {
     super(props);
     this.state = {
       localization: null,
@@ -20,7 +22,10 @@ class Post extends React.Component<PostProps, PostState> {
     };
   }
 
-  shouldComponentUpdate(nextProps: PostProps, nextState: PostState): boolean {
+  shouldComponentUpdate(
+    nextProps: PostProps & LanguageContextType,
+    nextState: PostState,
+  ): boolean {
     const currentPost = this.props.post;
     const nextPost = nextProps.post;
 
@@ -35,6 +40,10 @@ class Post extends React.Component<PostProps, PostState> {
       return true;
     }
 
+    if (this.props.currentLanguage !== nextProps.currentLanguage) {
+      return true;
+    }
+
     return false;
   }
 
@@ -42,7 +51,7 @@ class Post extends React.Component<PostProps, PostState> {
     this.loadLocalization();
   }
 
-  componentDidUpdate(prevProps: PostProps) {
+  componentDidUpdate(prevProps: PostProps & LanguageContextType) {
     if (
       prevProps.post.titleLocalizationUuid !==
       this.props.post.titleLocalizationUuid
@@ -77,6 +86,7 @@ class Post extends React.Component<PostProps, PostState> {
 
   render() {
     const { localization, loading } = this.state;
+    const { getLocalizedContent } = this.props;
 
     if (loading) {
       return <PostSkeleton />;
@@ -86,10 +96,10 @@ class Post extends React.Component<PostProps, PostState> {
       <Typography
         variant='body2'
         sx={{ fontSize: '1.333rem', color: 'var(--darkGray)' }}>
-        {localization?.default ?? ''}
+        {getLocalizedContent(localization)}
       </Typography>
     );
   }
 }
 
-export default Post;
+export default withLanguage(Post);

--- a/src/pages/NoticeDetail/components/NoticeDetailContent.tsx
+++ b/src/pages/NoticeDetail/components/NoticeDetailContent.tsx
@@ -4,16 +4,18 @@ import { Box, Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
 import RichTextViewer from '@/components/RichTextViewer';
+import { withLanguage } from '@/contexts/LanguageContext';
+import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
 import { NoticeContentProps } from '@/types/NoticeDetail/NoticeDetailContent.type';
 import { NoticeDetailContentState } from '@/types/NoticeDetail/NoticeDetailContent.type';
 
 import NoticeDetailContentSkeleton from './NoticeDetailContentSkeleton';
 
 class NoticeDetailContent extends React.Component<
-  NoticeContentProps,
+  NoticeContentProps & LanguageContextType,
   NoticeDetailContentState
 > {
-  constructor(props: NoticeContentProps) {
+  constructor(props: NoticeContentProps & LanguageContextType) {
     super(props);
     this.state = {
       localization: null,
@@ -22,7 +24,7 @@ class NoticeDetailContent extends React.Component<
   }
 
   shouldComponentUpdate(
-    nextProps: NoticeContentProps,
+    nextProps: NoticeContentProps & LanguageContextType,
     nextState: NoticeDetailContentState,
   ): boolean {
     if (this.props.uuid !== nextProps.uuid) {
@@ -36,6 +38,10 @@ class NoticeDetailContent extends React.Component<
       return true;
     }
 
+    if (this.props.currentLanguage !== nextProps.currentLanguage) {
+      return true;
+    }
+
     return false;
   }
 
@@ -43,7 +49,7 @@ class NoticeDetailContent extends React.Component<
     this.fetchLocalizationData();
   }
 
-  componentDidUpdate(prevProps: NoticeContentProps) {
+  componentDidUpdate(prevProps: NoticeContentProps & LanguageContextType) {
     if (prevProps.uuid !== this.props.uuid) {
       this.fetchLocalizationData();
     }
@@ -63,6 +69,7 @@ class NoticeDetailContent extends React.Component<
 
   render() {
     const { loading, localization } = this.state;
+    const { getLocalizedContent } = this.props;
 
     if (loading) {
       return <NoticeDetailContentSkeleton />;
@@ -74,10 +81,10 @@ class NoticeDetailContent extends React.Component<
 
     return (
       <Box pt={2}>
-        <RichTextViewer content={localization.default} />
+        <RichTextViewer content={getLocalizedContent(localization)} />
       </Box>
     );
   }
 }
 
-export default NoticeDetailContent;
+export default withLanguage(NoticeDetailContent);

--- a/src/pages/NoticeDetail/components/NoticeDetailTitle.tsx
+++ b/src/pages/NoticeDetail/components/NoticeDetailTitle.tsx
@@ -3,16 +3,18 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
+import { withLanguage } from '@/contexts/LanguageContext';
+import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
 import { NoticeTitleProps } from '@/types/NoticeDetail/NoticeDetailTitle.type';
 import { NoticeDetailTitleState } from '@/types/NoticeDetail/NoticeDetailTitle.type';
 
 import NoticeDetailTitleSkeleton from './NoticeDetailTitleSkeleton';
 
 class NoticeDetailTitle extends React.Component<
-  NoticeTitleProps,
+  NoticeTitleProps & LanguageContextType,
   NoticeDetailTitleState
 > {
-  constructor(props: NoticeTitleProps) {
+  constructor(props: NoticeTitleProps & LanguageContextType) {
     super(props);
     this.state = {
       localization: null,
@@ -21,7 +23,7 @@ class NoticeDetailTitle extends React.Component<
   }
 
   shouldComponentUpdate(
-    nextProps: NoticeTitleProps,
+    nextProps: NoticeTitleProps & LanguageContextType,
     nextState: NoticeDetailTitleState,
   ): boolean {
     if (this.props.uuid !== nextProps.uuid) {
@@ -35,6 +37,10 @@ class NoticeDetailTitle extends React.Component<
       return true;
     }
 
+    if (this.props.currentLanguage !== nextProps.currentLanguage) {
+      return true;
+    }
+
     return false;
   }
 
@@ -42,7 +48,7 @@ class NoticeDetailTitle extends React.Component<
     this.fetchLocalizationData();
   }
 
-  componentDidUpdate(prevProps: NoticeTitleProps) {
+  componentDidUpdate(prevProps: NoticeTitleProps & LanguageContextType) {
     if (prevProps.uuid !== this.props.uuid) {
       this.fetchLocalizationData();
     }
@@ -62,6 +68,7 @@ class NoticeDetailTitle extends React.Component<
 
   render() {
     const { loading, localization } = this.state;
+    const { getLocalizedContent } = this.props;
 
     if (loading) {
       return <NoticeDetailTitleSkeleton />;
@@ -80,11 +87,11 @@ class NoticeDetailTitle extends React.Component<
             fontWeight: 'bold',
             color: 'var(--darkGray)',
           }}>
-          {localization.default}
+          {getLocalizedContent(localization)}
         </Typography>
       </Box>
     );
   }
 }
 
-export default NoticeDetailTitle;
+export default withLanguage(NoticeDetailTitle);

--- a/src/types/LanguageContext/LanguageContext.type.ts
+++ b/src/types/LanguageContext/LanguageContext.type.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+import { ILocalization } from '@carebell/bell-core';
+
+export type Language = 'default' | 'ko' | 'en' | 'ja';
+
+export interface LanguageContextType {
+  currentLanguage: Language;
+  setLanguage: (language: Language) => void;
+  getLocalizedContent: (localization: ILocalization | null) => string;
+}
+
+export interface LanguageProviderProps {
+  children: ReactNode;
+}
+
+export interface LanguageProviderState {
+  currentLanguage: Language;
+}


### PR DESCRIPTION
## 📋 변경 사항
메인 페이지의 select box에서 언어 설정 버튼을 클릭하면 해당 언어로 변경하는 기능 구현

### 🔍 구현 세부사항
- `LanguageContext.tsx`라는 언어 관리 context 생성
- 기본 언어: default && 로컬 스토리지에 영구 저장하여 해당 정보를 기본값으로 가져옴

(언어 설정시)
1. `index.html`의 html lang 업데이트, body class 업데이트
2. `Post.tsx`, `NoticeDetailContent.tsx`, `NoticeDetailTitle.tsx`과 같이 localization이 필요한 컴포넌트에 언어 설정 정보 전달 (HOC)

### 🛡️ Fallback 처리
- 선택된 언어의 번역이 없을 경우 `default` 값으로 자동 fallback
- 로컬스토리지 접근 실패 시 `default` 언어로 안전하게 처리
- 유효하지 않은 언어 값 검증 및 기본값 적용

## 🗂️ 관련 이슈 필터링
#16 