### PR TITLE
[Refactor/context-18] 🔨 Refactor: Context API -> consumer 패턴 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter } from 'react-router-dom';
 
 import { ErrorProvider } from '@/contexts/ErrorContext';
-import { LanguageProvider } from '@/contexts/LanguageContext';
+import { LanguageProvider } from '@/contexts/LanguageProvider';
 import Router from '@/routes/Router';
 
 function App() {

--- a/src/contexts/LanguageContext.ts
+++ b/src/contexts/LanguageContext.ts
@@ -1,0 +1,10 @@
+import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+
+export const validateLanguageContext = (
+  context: LanguageContextType | undefined,
+): LanguageContextType => {
+  if (!context) {
+    throw new Error('LanguageProvider 내에서 컴포넌트를 사용해야 함');
+  }
+  return context;
+};

--- a/src/contexts/LanguageProvider.tsx
+++ b/src/contexts/LanguageProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Component } from 'react';
+import { createContext, Component } from 'react';
 
 import { ILocalization } from '@carebell/bell-core';
 
@@ -105,35 +105,5 @@ export class LanguageProvider extends Component<
     );
   }
 }
-
-export function withLanguage<P extends object>(
-  WrappedComponent: React.ComponentType<P & LanguageContextType>,
-) {
-  return class WithLanguageComponent extends Component<P> {
-    static contextType = LanguageContext;
-    declare context: React.ContextType<typeof LanguageContext>;
-
-    render() {
-      if (!this.context) {
-        throw new Error('withLanguage must be used within a LanguageProvider');
-      }
-
-      return (
-        <WrappedComponent
-          {...(this.props as P)}
-          {...this.context}
-        />
-      );
-    }
-  };
-}
-
-export const useLanguage = (): LanguageContextType => {
-  const context = React.useContext(LanguageContext);
-  if (context === undefined) {
-    throw new Error('언어 컨텍스트가 없습니다.');
-  }
-  return context;
-};
 
 export { LanguageContext };

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -6,22 +6,25 @@ import { FormControl, InputLabel } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 
-import { withLanguage } from '@/contexts/LanguageContext';
-import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+import { validateLanguageContext } from '@/contexts/LanguageContext';
+import { LanguageContext } from '@/contexts/LanguageProvider';
 
-class MainPage extends React.Component<LanguageContextType> {
+class MainPage extends React.Component {
+  static contextType = LanguageContext;
+  declare context: React.ContextType<typeof LanguageContext>;
+
   handleChange = (event: SelectChangeEvent) => {
     const selectedLanguage = event.target.value as
       | 'default'
       | 'ko'
       | 'en'
       | 'ja';
-    this.props.setLanguage(selectedLanguage);
+    validateLanguageContext(this.context).setLanguage(selectedLanguage);
     console.log('언어 변경', selectedLanguage);
   };
 
   render() {
-    const { currentLanguage } = this.props;
+    const { currentLanguage } = validateLanguageContext(this.context);
 
     return (
       <div>
@@ -44,4 +47,4 @@ class MainPage extends React.Component<LanguageContextType> {
   }
 }
 
-export default withLanguage(MainPage);
+export default MainPage;

--- a/src/pages/Notice/components/Post.tsx
+++ b/src/pages/Notice/components/Post.tsx
@@ -4,17 +4,17 @@ import { Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
 import { ErrorContext } from '@/contexts/ErrorContext';
-import { withLanguage } from '@/contexts/LanguageContext';
-import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+import { validateLanguageContext } from '@/contexts/LanguageContext';
+import { LanguageContext } from '@/contexts/LanguageProvider';
 import { PostProps, PostState } from '@/types/Notice/Post.type';
 
 import PostSkeleton from './PostSkeleton';
 
-class Post extends React.Component<PostProps & LanguageContextType, PostState> {
+class Post extends React.Component<PostProps, PostState> {
   static contextType = ErrorContext;
   declare context: React.ContextType<typeof ErrorContext>;
 
-  constructor(props: PostProps & LanguageContextType) {
+  constructor(props: PostProps) {
     super(props);
     this.state = {
       localization: null,
@@ -22,10 +22,7 @@ class Post extends React.Component<PostProps & LanguageContextType, PostState> {
     };
   }
 
-  shouldComponentUpdate(
-    nextProps: PostProps & LanguageContextType,
-    nextState: PostState,
-  ): boolean {
+  shouldComponentUpdate(nextProps: PostProps, nextState: PostState): boolean {
     const currentPost = this.props.post;
     const nextPost = nextProps.post;
 
@@ -40,10 +37,6 @@ class Post extends React.Component<PostProps & LanguageContextType, PostState> {
       return true;
     }
 
-    if (this.props.currentLanguage !== nextProps.currentLanguage) {
-      return true;
-    }
-
     return false;
   }
 
@@ -51,7 +44,7 @@ class Post extends React.Component<PostProps & LanguageContextType, PostState> {
     this.loadLocalization();
   }
 
-  componentDidUpdate(prevProps: PostProps & LanguageContextType) {
+  componentDidUpdate(prevProps: PostProps) {
     if (
       prevProps.post.titleLocalizationUuid !==
       this.props.post.titleLocalizationUuid
@@ -86,20 +79,27 @@ class Post extends React.Component<PostProps & LanguageContextType, PostState> {
 
   render() {
     const { localization, loading } = this.state;
-    const { getLocalizedContent } = this.props;
 
     if (loading) {
       return <PostSkeleton />;
     }
 
     return (
-      <Typography
-        variant='body2'
-        sx={{ fontSize: '1.333rem', color: 'var(--darkGray)' }}>
-        {getLocalizedContent(localization)}
-      </Typography>
+      <LanguageContext.Consumer>
+        {(languageContext) => {
+          const validatedContext = validateLanguageContext(languageContext);
+
+          return (
+            <Typography
+              variant='body2'
+              sx={{ fontSize: '1.333rem', color: 'var(--darkGray)' }}>
+              {validatedContext.getLocalizedContent(localization)}
+            </Typography>
+          );
+        }}
+      </LanguageContext.Consumer>
     );
   }
 }
 
-export default withLanguage(Post);
+export default Post;

--- a/src/pages/NoticeDetail/components/NoticeDetailContent.tsx
+++ b/src/pages/NoticeDetail/components/NoticeDetailContent.tsx
@@ -4,18 +4,21 @@ import { Box, Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
 import RichTextViewer from '@/components/RichTextViewer';
-import { withLanguage } from '@/contexts/LanguageContext';
-import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+import { validateLanguageContext } from '@/contexts/LanguageContext';
+import { LanguageContext } from '@/contexts/LanguageProvider';
 import { NoticeContentProps } from '@/types/NoticeDetail/NoticeDetailContent.type';
 import { NoticeDetailContentState } from '@/types/NoticeDetail/NoticeDetailContent.type';
 
 import NoticeDetailContentSkeleton from './NoticeDetailContentSkeleton';
 
 class NoticeDetailContent extends React.Component<
-  NoticeContentProps & LanguageContextType,
+  NoticeContentProps,
   NoticeDetailContentState
 > {
-  constructor(props: NoticeContentProps & LanguageContextType) {
+  static contextType = LanguageContext;
+  declare context: React.ContextType<typeof LanguageContext>;
+
+  constructor(props: NoticeContentProps) {
     super(props);
     this.state = {
       localization: null,
@@ -24,7 +27,7 @@ class NoticeDetailContent extends React.Component<
   }
 
   shouldComponentUpdate(
-    nextProps: NoticeContentProps & LanguageContextType,
+    nextProps: NoticeContentProps,
     nextState: NoticeDetailContentState,
   ): boolean {
     if (this.props.uuid !== nextProps.uuid) {
@@ -38,10 +41,6 @@ class NoticeDetailContent extends React.Component<
       return true;
     }
 
-    if (this.props.currentLanguage !== nextProps.currentLanguage) {
-      return true;
-    }
-
     return false;
   }
 
@@ -49,7 +48,7 @@ class NoticeDetailContent extends React.Component<
     this.fetchLocalizationData();
   }
 
-  componentDidUpdate(prevProps: NoticeContentProps & LanguageContextType) {
+  componentDidUpdate(prevProps: NoticeContentProps) {
     if (prevProps.uuid !== this.props.uuid) {
       this.fetchLocalizationData();
     }
@@ -69,7 +68,7 @@ class NoticeDetailContent extends React.Component<
 
   render() {
     const { loading, localization } = this.state;
-    const { getLocalizedContent } = this.props;
+    const { getLocalizedContent } = validateLanguageContext(this.context);
 
     if (loading) {
       return <NoticeDetailContentSkeleton />;
@@ -87,4 +86,4 @@ class NoticeDetailContent extends React.Component<
   }
 }
 
-export default withLanguage(NoticeDetailContent);
+export default NoticeDetailContent;

--- a/src/pages/NoticeDetail/components/NoticeDetailTitle.tsx
+++ b/src/pages/NoticeDetail/components/NoticeDetailTitle.tsx
@@ -3,18 +3,21 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 
 import { fetchLocalization } from '@/api/notice';
-import { withLanguage } from '@/contexts/LanguageContext';
-import { LanguageContextType } from '@/types/LanguageContext/LanguageContext.type';
+import { validateLanguageContext } from '@/contexts/LanguageContext';
+import { LanguageContext } from '@/contexts/LanguageProvider';
 import { NoticeTitleProps } from '@/types/NoticeDetail/NoticeDetailTitle.type';
 import { NoticeDetailTitleState } from '@/types/NoticeDetail/NoticeDetailTitle.type';
 
 import NoticeDetailTitleSkeleton from './NoticeDetailTitleSkeleton';
 
 class NoticeDetailTitle extends React.Component<
-  NoticeTitleProps & LanguageContextType,
+  NoticeTitleProps,
   NoticeDetailTitleState
 > {
-  constructor(props: NoticeTitleProps & LanguageContextType) {
+  static contextType = LanguageContext;
+  declare context: React.ContextType<typeof LanguageContext>;
+
+  constructor(props: NoticeTitleProps) {
     super(props);
     this.state = {
       localization: null,
@@ -23,7 +26,7 @@ class NoticeDetailTitle extends React.Component<
   }
 
   shouldComponentUpdate(
-    nextProps: NoticeTitleProps & LanguageContextType,
+    nextProps: NoticeTitleProps,
     nextState: NoticeDetailTitleState,
   ): boolean {
     if (this.props.uuid !== nextProps.uuid) {
@@ -37,10 +40,6 @@ class NoticeDetailTitle extends React.Component<
       return true;
     }
 
-    if (this.props.currentLanguage !== nextProps.currentLanguage) {
-      return true;
-    }
-
     return false;
   }
 
@@ -48,7 +47,7 @@ class NoticeDetailTitle extends React.Component<
     this.fetchLocalizationData();
   }
 
-  componentDidUpdate(prevProps: NoticeTitleProps & LanguageContextType) {
+  componentDidUpdate(prevProps: NoticeTitleProps) {
     if (prevProps.uuid !== this.props.uuid) {
       this.fetchLocalizationData();
     }
@@ -68,7 +67,7 @@ class NoticeDetailTitle extends React.Component<
 
   render() {
     const { loading, localization } = this.state;
-    const { getLocalizedContent } = this.props;
+    const { getLocalizedContent } = validateLanguageContext(this.context);
 
     if (loading) {
       return <NoticeDetailTitleSkeleton />;
@@ -94,4 +93,4 @@ class NoticeDetailTitle extends React.Component<
   }
 }
 
-export default withLanguage(NoticeDetailTitle);
+export default NoticeDetailTitle;


### PR DESCRIPTION
## 📋 변경 사항
✅ HOC 방식 → 직접 Context 사용
withLanguage HOC 제거하고 static contextType 또는 Consumer 패턴 사용
✅ 중복 에러 처리 제거
validateLanguageContext 헬퍼 함수로 중앙화
( `+` Fast Refresh 에러 해결을 위해 컴포넌트 <-> 헬퍼 함수 분리)

## 🗂️ 관련 이슈 필터링
#18 